### PR TITLE
Remove dependency on is-buffer

### DIFF
--- a/ndarray.js
+++ b/ndarray.js
@@ -1,5 +1,7 @@
 var iota = require("iota-array")
-var isBuffer = require("is-buffer")
+function isBuffer(val) {
+  return ![, null].includes(val) && val.constructor === Buffer;
+}
 
 var hasTypedArrays  = ((typeof Float64Array) !== "undefined")
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "iota-array": "^1.0.0",
-    "is-buffer": "^1.0.2"
+    "iota-array": "^1.0.0"
   },
   "devDependencies": {
     "permutation-rank": "^1.0.0",


### PR DESCRIPTION
As the package was only used once in the code, I removed the dependency from `package.json` and added a function that performs exactly the same check for a value.