### PR TITLE
Support BigInt64Array/BigUint64Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Data type | String
 `Uint8Array` | "uint8"
 `Uint16Array` | "uint16"
 `Uint32Array` | "uint32"
+`BigInt64Array` | "bigint64"
+`BigUint64Array` | "biguint64"
 `Float32Array` | "float32"
 `Float64Array` | "float64"
 `Array` | "array"

--- a/ndarray.js
+++ b/ndarray.js
@@ -276,6 +276,10 @@ function arrayDType(data) {
         return "uint32"
       case "[object Uint8ClampedArray]":
         return "uint8_clamped"
+      case "[object BigInt64Array]":
+        return "bigint64"
+      case "[object BigUint64Array]":
+        return "biguint64"
     }
   }
   if(Array.isArray(data)) {
@@ -295,6 +299,8 @@ var CACHED_CONSTRUCTORS = {
   "uint32":[],
   "array":[],
   "uint8_clamped":[],
+  "bigint64": [],
+  "biguint64": [],
   "buffer":[],
   "generic":[]
 }

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,17 @@ test("uint8clamped", function(t) {
   t.end()
 })
 
+if((typeof BigInt64Array) !== "undefined")
+test("bigint64", function(t) {
+  var p = ndarray(new BigInt64Array([1,2,3,4].map(BigInt)), [4])
+  t.equals(p.dtype, "bigint64")
+  t.equals(p.get(0), BigInt(1))
+  t.equals(p.get(1), BigInt(2))
+  t.equals(p.get(2), BigInt(3))
+  t.equals(p.get(3), BigInt(4))
+  t.end()
+})
+
 test("buffer", function(t) {
   var p = ndarray(new Buffer(5))
   t.equals(p.dtype, "buffer")


### PR DESCRIPTION
Add support for typed arrays of 64-bit integers (BigInt) now available
in many browsers. Without this patch these typed arrays were given the
"generic" dtype, which then attempted to use getters and setters rather
than indexing, causing an error since typed arrays do not provide these.

These changes are compatible with browsers that do not have these 64-bit
typed arrays.

Simple tests are included.